### PR TITLE
Dumb state/action/reducer/container

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -1,8 +1,3 @@
-body {
-  color: white;
-  background-color: black;
-}
-
 .app {
   margin-top: 20px;
   margin-bottom: 20px;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,1 +1,8 @@
-// TODO: add and export your own actions
+// TODO: remove updateDumb action, add and export your own actions
+
+export function updateDumb(newValue) {
+  return {
+    type: 'UPDATE_DUMB',
+    payload: newValue
+  }
+}

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import Dumb from '../containers/dumb';
 
 const App = () => {
   return (
     <div className="app">
       <p>React + Redux starter</p>
+      <Dumb />
     </div>
   );
 };

--- a/src/containers/dumb.jsx
+++ b/src/containers/dumb.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import { updateDumb } from '../actions';
+
+class Dumb extends Component {
+  handleClick = () => {
+    this.props.updateDumb(`${this.props.dumb}!`);
+  }
+
+  render() {
+    const style = { cursor: 'pointer' };
+    return (
+      <div onClick={this.handleClick} style={style}>
+        {this.props.dumb}
+      </div>
+    );
+  }
+};
+
+function mapStateToProps(state) {
+  return { dumb: state.dumb };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ updateDumb }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Dumb);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,21 +2,34 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { createStore, combineReducers } from 'redux';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
 
-// internal modules
-import App from './components/app';
 import '../assets/stylesheets/application.scss';
+import App from './components/app';
+
+import dumbReducer from './reducers/dumb_reducer'
 
 // State and reducers
+const initialState = {
+  // TODO: Define your Redux state and remove the `dumb` key.
+  dumb: "Click me"
+};
 const reducers = combineReducers({
-  state: (state = {}, action) => state
+  // TODO: create and import a reducer for each redux state key. Remove dumb.
+  dumb: dumbReducer
 });
 
-// render an instance of the component in the DOM
+const middlewares = applyMiddleware(
+  // TODO: import and list middlewares you want to use.
+  // e.g.: logger, ReduxPromise, etc.
+);
+
+const store = createStore(reducers, initialState, middlewares);
+
 ReactDOM.render(
-  <Provider store={createStore(reducers)}>
+  <Provider store={store}>
     <App />
   </Provider>,
   document.querySelector('.container')
 );
+

--- a/src/reducers/dumb_reducer.js
+++ b/src/reducers/dumb_reducer.js
@@ -1,0 +1,8 @@
+export default function(state = null, action) {
+  switch (action.type) {
+    case 'UPDATE_DUMB':
+      return action.payload; // New value for dumb state
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
@Eschults I'd like this boilerplate to remind people how the whole Redux thing works. So having a default state key (`dumb`) with its associated `dumbReducer`. Then an action `UPDATE_DUMB` called from a `<Dumb />` container which uses `connect`, `mapStateToProps` and `mapDispatchToProps`. This way, instead of starting from empty folders, they can create their own components from a copy-paste of these (removing them later).

What do you think?